### PR TITLE
Add data origin filtering to queryAggregated and new queryRecords method

### DIFF
--- a/android/src/main/java/com/fit_up/health/capacitor/HealthPlugin.kt
+++ b/android/src/main/java/com/fit_up/health/capacitor/HealthPlugin.kt
@@ -18,6 +18,7 @@ import androidx.health.connect.client.records.ExerciseSessionRecord
 import androidx.health.connect.client.records.HeartRateRecord
 import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
+import androidx.health.connect.client.records.metadata.DataOrigin
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.request.ReadRecordsRequest
@@ -282,11 +283,12 @@ class HealthPlugin : Plugin() {
                 else -> throw RuntimeException("Unsupported bucket: $bucket")
             }
 
+            val dataOrigins = parseDataOrigins(call)
 
             CoroutineScope(Dispatchers.IO).launch {
                 try {
 
-                    val r = queryAggregatedMetric(metricAndMapper, TimeRangeFilter.between(startDateTime, endDateTime), period)
+                    val r = queryAggregatedMetric(metricAndMapper, TimeRangeFilter.between(startDateTime, endDateTime), period, dataOrigins)
 
                     val aggregatedList = JSArray()
                     r.forEach { aggregatedList.put(it.toJs()) }
@@ -341,6 +343,7 @@ class HealthPlugin : Plugin() {
 
     private suspend fun queryAggregatedMetric(
         metricAndMapper: MetricAndMapper, timeRange: TimeRangeFilter, period: Period,
+        dataOrigins: Set<DataOrigin> = emptySet(),
     ): List<AggregatedSample> {
         if (!hasPermission(metricAndMapper.permission)) {
             return emptyList()
@@ -350,7 +353,8 @@ class HealthPlugin : Plugin() {
             AggregateGroupByPeriodRequest(
                 metrics = setOf(metricAndMapper.metric),
                 timeRangeFilter = timeRange,
-                timeRangeSlicer = period
+                timeRangeSlicer = period,
+                dataOriginsFilter = dataOrigins
             )
         )
 
@@ -359,6 +363,68 @@ class HealthPlugin : Plugin() {
             AggregatedSample(it.startTime, it.endTime, mappedValue)
         }
 
+    }
+
+    private fun parseDataOrigins(call: PluginCall): Set<DataOrigin> {
+        val originsArray = call.getArray("dataOrigins") ?: return emptySet()
+        return (0 until originsArray.length())
+            .map { originsArray.getString(it) }
+            .filter { it.isNotEmpty() }
+            .map { DataOrigin(it) }
+            .toSet()
+    }
+
+    @PluginMethod
+    fun queryRecords(call: PluginCall) {
+        try {
+            val startDate = call.getString("startDate")
+            val endDate = call.getString("endDate")
+            val dataType = call.getString("dataType")
+
+            if (startDate == null || endDate == null || dataType == null) {
+                call.reject("Missing required parameters: startDate, endDate, or dataType")
+                return
+            }
+
+            if (dataType != "steps") {
+                call.reject("queryRecords currently only supports dataType 'steps'")
+                return
+            }
+
+            if (!hasPermission(CapHealthPermission.READ_STEPS)) {
+                call.reject("READ_STEPS permission not granted")
+                return
+            }
+
+            val startInstant = Instant.parse(startDate)
+            val endInstant = Instant.parse(endDate)
+            val timeRange = TimeRangeFilter.between(startInstant, endInstant)
+            val request = ReadRecordsRequest(StepsRecord::class, timeRange)
+
+            CoroutineScope(Dispatchers.IO).launch {
+                try {
+                    val response = healthConnectClient.readRecords(request)
+                    val recordsArray = JSArray()
+
+                    for (record in response.records) {
+                        val obj = JSObject()
+                        obj.put("startDate", record.startTime.toString())
+                        obj.put("endDate", record.endTime.toString())
+                        obj.put("value", record.count)
+                        obj.put("sourceBundleId", record.metadata.dataOrigin.packageName)
+                        recordsArray.put(obj)
+                    }
+
+                    val result = JSObject()
+                    result.put("records", recordsArray)
+                    call.resolve(result)
+                } catch (e: Exception) {
+                    call.reject("Error querying records: ${e.message}")
+                }
+            }
+        } catch (e: Exception) {
+            call.reject(e.message)
+        }
     }
 
     private suspend fun hasPermission(p: CapHealthPermission): Boolean {

--- a/ios/Sources/HealthPluginPlugin/HealthPlugin.swift
+++ b/ios/Sources/HealthPluginPlugin/HealthPlugin.swift
@@ -16,7 +16,8 @@ public class HealthPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "requestHealthPermissions", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "openAppleHealthSettings", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "queryAggregated", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "queryWorkouts", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "queryWorkouts", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "queryRecords", returnType: CAPPluginReturnPromise)
     ]
     
     let healthStore = HKHealthStore()
@@ -133,13 +134,16 @@ public class HealthPlugin: CAPPlugin, CAPBridgedPlugin {
             }
             
             
+            // Note: dataOrigins is accepted for API compatibility with Android
+            // but is not applied on iOS. Apple Health already de-duplicates data
+            // from multiple sources automatically.
             let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: .strictStartDate)
-            
+
             guard let interval = calculateInterval(bucket: bucket) else {
                 call.reject("Invalid bucket")
                 return
             }
-            
+
             let query = HKStatisticsCollectionQuery(
                 quantityType: dataType,
                 quantitySamplePredicate: predicate,
@@ -264,6 +268,12 @@ public class HealthPlugin: CAPPlugin, CAPBridgedPlugin {
     
     
     
+    @objc func queryRecords(_ call: CAPPluginCall) {
+        // Apple Health de-duplicates data automatically, so per-source record
+        // inspection is not needed on iOS.
+        call.reject("queryRecords is only available on Android")
+    }
+
     func calculateInterval(bucket: String) -> DateComponents? {
         switch bucket {
         case "hour":

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -55,6 +55,17 @@ export interface HealthPlugin {
    * @param request
    */
   queryWorkouts(request: QueryWorkoutRequest): Promise<QueryWorkoutResponse>;
+
+  /**
+   * Query individual records for a given data type. Unlike queryAggregated,
+   * this returns each record separately with its data origin, which is useful
+   * for detecting duplicate sources.
+   *
+   * Android only. iOS rejects with "not implemented".
+   *
+   * @param request
+   */
+  queryRecords(request: QueryRecordsRequest): Promise<QueryRecordsResponse>;
 }
 
 export declare type HealthPermission =
@@ -119,6 +130,15 @@ export interface QueryAggregatedRequest {
   endDate: string;
   dataType: 'steps' | 'active-calories' | 'mindfulness';
   bucket: string;
+  /**
+   * Optional list of package names (Android) or bundle identifiers (iOS) to
+   * restrict the aggregation to. When omitted or empty, data from all sources
+   * is included.
+   *
+   * Example: `['com.sec.android.app.shealth']` to only aggregate Samsung
+   * Health data.
+   */
+  dataOrigins?: string[];
 }
 
 export interface QueryAggregatedResponse {
@@ -129,4 +149,21 @@ export interface AggregatedSample {
   startDate: string;
   endDate: string;
   value: number;
+}
+
+export interface QueryRecordsRequest {
+  startDate: string;
+  endDate: string;
+  dataType: 'steps';
+}
+
+export interface HealthRecord {
+  startDate: string;
+  endDate: string;
+  value: number;
+  sourceBundleId: string;
+}
+
+export interface QueryRecordsResponse {
+  records: HealthRecord[];
 }


### PR DESCRIPTION
Hey there! First off, thank you for building this plugin — we use it at our company and it's been great to work with. We ran into an issue with multi-source step data on Android and wanted to contribute a fix upstream.

## Problem

On Android, when multiple apps write step data to Health Connect (e.g. Samsung Health + a smartwatch app + Google Fit), `queryAggregated` sums steps from **all** sources because `AggregateGroupByPeriodRequest` is constructed without a `dataOriginsFilter`. This leads to significantly inflated step counts — in our case, users were seeing 2–3x their actual steps because Health Connect was aggregating overlapping data from multiple apps.

## Solution

Two complementary features:

### 1. `dataOrigins` parameter on `queryAggregated`

Health Connect's `AggregateGroupByPeriodRequest` already accepts a `dataOriginsFilter` parameter, but the plugin wasn't passing it through. This PR adds an optional `dataOrigins` string array to `QueryAggregatedRequest` so callers can restrict aggregation to specific package names. When omitted, behavior is unchanged (all sources).

### 2. New `queryRecords` method

Returns individual step records with their `sourceBundleId`, which lets callers detect when multiple sources are contributing data and take appropriate action (warn the user, pick a primary source, etc.). Currently supports `dataType: 'steps'` only.

These two features work together: `queryRecords` lets you **discover** which sources are contributing data, and `dataOrigins` lets you **filter** to the right one.

## Platform notes

- **Android**: Both features fully implemented
- **iOS**: `dataOrigins` is accepted for API compatibility but not applied — Apple Health already handles deduplication automatically. `queryRecords` rejects with a clear message since it's not needed on iOS.

## Usage examples

```typescript
// Detect multiple step sources
const records = await Health.queryRecords({
  startDate: start.toISOString(),
  endDate: end.toISOString(),
  dataType: 'steps'
});
const sources = [...new Set(records.records.map(r => r.sourceBundleId))];
if (sources.length > 1) {
  // Prompt user to pick their preferred source
}

// Filter aggregation to a single source
const result = await Health.queryAggregated({
  startDate: start.toISOString(),
  endDate: end.toISOString(),
  dataType: 'steps',
  bucket: 'day',
  dataOrigins: ['com.sec.android.app.shealth']
});
```

## Changes

- `src/definitions.ts` — Added `dataOrigins` to `QueryAggregatedRequest`, new `queryRecords` method and types
- `HealthPlugin.kt` — Passes `dataOriginsFilter` to `AggregateGroupByPeriodRequest`, adds `parseDataOrigins` helper, adds `queryRecords` implementation using `ReadRecordsRequest<StepsRecord>`
- `HealthPlugin.swift` — Registers new method, accepts `dataOrigins` gracefully, stubs `queryRecords`

Happy to adjust anything based on your feedback. Thanks again for the great plugin! 🙏