### PR TITLE
Add querySleep for Apple Health and Health Connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ npx cap sync
 * [`showHealthConnectInPlayStore()`](#showhealthconnectinplaystore)
 * [`queryAggregated(...)`](#queryaggregated)
 * [`queryWorkouts(...)`](#queryworkouts)
+* [`querySleep(...)`](#querysleep)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
 
@@ -208,6 +209,33 @@ Query workouts
 --------------------
 
 
+### querySleep(...)
+
+```typescript
+querySleep(request: QuerySleepRequest) => Promise<QuerySleepResponse>
+```
+
+Query sleep sessions.
+
+Android: Reads Health Connect `SleepSessionRecord`s. Each session already
+carries its own stages (awake / light / deep / rem / ...).
+
+iOS: HealthKit has no native sleep-session concept, only individual sleep
+analysis category samples. Contiguous samples from the same source are
+grouped into a session; samples separated by more than `sessionGapMinutes`
+(default 60) start a new session. Each underlying sample becomes a stage.
+
+Requires the `READ_SLEEP` permission.
+
+| Param         | Type                                                            |
+| ------------- | --------------------------------------------------------------- |
+| **`request`** | <code><a href="#querysleeprequest">QuerySleepRequest</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#querysleepresponse">QuerySleepResponse</a>&gt;</code>
+
+--------------------
+
+
 ### Interfaces
 
 
@@ -247,7 +275,7 @@ Query workouts
 | --------------- | ---------------------------------- |
 | **`startDate`** | <code>string</code>                |
 | **`endDate`**   | <code>string</code>                |
-| **`dataType`**  | <code>'steps' \| 'calories'</code> |
+| **`dataType`**  | <code>'steps' \| 'active-calories' \| 'mindfulness' \| 'sleep'</code> |
 | **`bucket`**    | <code>string</code>                |
 
 
@@ -303,11 +331,55 @@ Query workouts
 | **`includeRoute`**     | <code>boolean</code> |
 
 
+#### QuerySleepResponse
+
+| Prop           | Type                         |
+| -------------- | ---------------------------- |
+| **`sessions`** | <code>SleepSession[]</code>  |
+
+
+#### SleepSession
+
+| Prop                 | Type                        | Description                                                                                                                                                                                       |
+| -------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`startDate`**      | <code>string</code>         | Start of the session (start of the first stage). ISO 8601 string.                                                                                                                               |
+| **`endDate`**        | <code>string</code>         | End of the session (end of the last stage). ISO 8601 string.                                                                                                                                    |
+| **`duration`**       | <code>number</code>         | Total time asleep in seconds, i.e. the summed duration of the asleep stages (`light` + `deep` + `rem` + `asleep`). Excludes `awake`, `inBed` and `outOfBed` stages.                              |
+| **`id`**             | <code>string</code>         | Identifier of the session. On Android this is the record id.                                                                                                                                    |
+| **`sourceName`**     | <code>string</code>         |                                                                                                                                                                                                 |
+| **`sourceBundleId`** | <code>string</code>         |                                                                                                                                                                                                 |
+| **`manual`**         | <code>boolean</code>        | True if the session was entered manually by the user rather than recorded by a device.                                                                                                          |
+| **`stages`**         | <code>SleepStage[]</code>   | Per-stage breakdown of the session, ordered by start time.                                                                                                                                      |
+
+
+#### SleepStage
+
+| Prop            | Type                                                      |
+| --------------- | -------------------------------------------------------- |
+| **`startDate`** | <code>string</code>                                      |
+| **`endDate`**   | <code>string</code>                                      |
+| **`stage`**     | <code><a href="#sleepstagetype">SleepStageType</a></code> |
+
+
+#### QuerySleepRequest
+
+| Prop                    | Type                | Description                                                                                                                                                                                  |
+| ----------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **`startDate`**         | <code>string</code> |                                                                                                                                                                                            |
+| **`endDate`**           | <code>string</code> |                                                                                                                                                                                            |
+| **`sessionGapMinutes`** | <code>number</code> | iOS only: maximum gap, in minutes, between two consecutive sleep samples from the same source for them to be treated as part of the same session. Defaults to 60. Ignored on Android. |
+
+
 ### Type Aliases
 
 
 #### HealthPermission
 
-<code>'READ_STEPS' | 'READ_WORKOUTS' | 'READ_CALORIES' | 'READ_DISTANCE' | 'READ_HEART_RATE' | 'READ_ROUTE'</code>
+<code>'READ_STEPS' | 'READ_WORKOUTS' | 'READ_CALORIES' | 'READ_DISTANCE' | 'READ_HEART_RATE' | 'READ_ROUTE' | 'READ_SLEEP'</code>
+
+
+#### SleepStageType
+
+<code>'awake' | 'asleep' | 'light' | 'deep' | 'rem' | 'inBed' | 'outOfBed' | 'unknown'</code>
 
 </docgen-api>

--- a/android/src/main/java/com/fit_up/health/capacitor/HealthPlugin.kt
+++ b/android/src/main/java/com/fit_up/health/capacitor/HealthPlugin.kt
@@ -16,9 +16,11 @@ import androidx.health.connect.client.records.DistanceRecord
 import androidx.health.connect.client.records.ExerciseRouteResult
 import androidx.health.connect.client.records.ExerciseSessionRecord
 import androidx.health.connect.client.records.HeartRateRecord
+import androidx.health.connect.client.records.SleepSessionRecord
 import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
 import androidx.health.connect.client.records.metadata.DataOrigin
+import androidx.health.connect.client.records.metadata.Metadata
 import androidx.health.connect.client.request.AggregateGroupByPeriodRequest
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.request.ReadRecordsRequest
@@ -42,7 +44,7 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.jvm.optionals.getOrDefault
 
 enum class CapHealthPermission {
-    READ_STEPS, READ_WORKOUTS, READ_HEART_RATE, READ_ROUTE, READ_ACTIVE_CALORIES, READ_TOTAL_CALORIES, READ_DISTANCE;
+    READ_STEPS, READ_WORKOUTS, READ_HEART_RATE, READ_ROUTE, READ_ACTIVE_CALORIES, READ_TOTAL_CALORIES, READ_DISTANCE, READ_SLEEP;
 
     companion object {
         fun from(s: String): CapHealthPermission? {
@@ -86,6 +88,10 @@ enum class CapHealthPermission {
         Permission(
             alias = "READ_ROUTE",
             strings = ["android.permission.health.READ_EXERCISE_ROUTE"]
+        ),
+        Permission(
+            alias = "READ_SLEEP",
+            strings = ["android.permission.health.READ_SLEEP"]
         )
     ]
 )
@@ -142,7 +148,8 @@ class HealthPlugin : Plugin() {
         Pair(CapHealthPermission.READ_ACTIVE_CALORIES, "android.permission.health.READ_ACTIVE_CALORIES_BURNED"),
         Pair(CapHealthPermission.READ_TOTAL_CALORIES, "android.permission.health.READ_TOTAL_CALORIES_BURNED"),
         Pair(CapHealthPermission.READ_DISTANCE, "android.permission.health.READ_DISTANCE"),
-        Pair(CapHealthPermission.READ_STEPS, "android.permission.health.READ_STEPS")
+        Pair(CapHealthPermission.READ_STEPS, "android.permission.health.READ_STEPS"),
+        Pair(CapHealthPermission.READ_SLEEP, "android.permission.health.READ_SLEEP")
     )
 
     // Check if a set of permissions are granted
@@ -256,6 +263,7 @@ class HealthPlugin : Plugin() {
                 TotalCaloriesBurnedRecord.ENERGY_TOTAL
             ) { it?.inKilocalories }
             "distance" -> metricAndMapper("distance", CapHealthPermission.READ_DISTANCE, DistanceRecord.DISTANCE_TOTAL) { it?.inMeters }
+            "sleep" -> metricAndMapper("sleep", CapHealthPermission.READ_SLEEP, SleepSessionRecord.SLEEP_DURATION_TOTAL) { it?.seconds?.toDouble() }
             else -> throw RuntimeException("Unsupported dataType: $dataType")
         }
     }
@@ -424,6 +432,91 @@ class HealthPlugin : Plugin() {
             }
         } catch (e: Exception) {
             call.reject(e.message)
+        }
+    }
+
+    @PluginMethod
+    fun querySleep(call: PluginCall) {
+        try {
+            val startDate = call.getString("startDate")
+            val endDate = call.getString("endDate")
+
+            if (startDate == null || endDate == null) {
+                call.reject("Missing required parameters: startDate or endDate")
+                return
+            }
+
+            val startInstant = Instant.parse(startDate)
+            val endInstant = Instant.parse(endDate)
+            val timeRange = TimeRangeFilter.between(startInstant, endInstant)
+            val request = ReadRecordsRequest(SleepSessionRecord::class, timeRange)
+
+            CoroutineScope(Dispatchers.IO).launch {
+                try {
+                    if (!hasPermission(CapHealthPermission.READ_SLEEP)) {
+                        call.reject("READ_SLEEP permission not granted")
+                        return@launch
+                    }
+
+                    val response = healthConnectClient.readRecords(request)
+                    val sessionsArray = JSArray()
+
+                    for (session in response.records) {
+                        val stagesArray = JSArray()
+                        var asleepSeconds = 0L
+                        for (stage in session.stages) {
+                            val stageName = sleepStageName(stage.stage)
+                            val stageObject = JSObject()
+                            stageObject.put("startDate", stage.startTime.toString())
+                            stageObject.put("endDate", stage.endTime.toString())
+                            stageObject.put("stage", stageName)
+                            stagesArray.put(stageObject)
+
+                            if (stageName == "asleep" || stageName == "light" || stageName == "deep" || stageName == "rem") {
+                                asleepSeconds += stage.endTime.epochSecond - stage.startTime.epochSecond
+                            }
+                        }
+
+                        // When a source provides no stage breakdown, treat the whole session as asleep.
+                        val duration = if (session.stages.isEmpty()) {
+                            session.endTime.epochSecond - session.startTime.epochSecond
+                        } else {
+                            asleepSeconds
+                        }
+
+                        val sessionObject = JSObject()
+                        sessionObject.put("id", session.metadata.id)
+                        sessionObject.put("startDate", session.startTime.toString())
+                        sessionObject.put("endDate", session.endTime.toString())
+                        sessionObject.put("duration", duration)
+                        sessionObject.put("sourceBundleId", session.metadata.dataOrigin.packageName)
+                        sessionObject.put("sourceName", session.metadata.device?.model ?: "")
+                        sessionObject.put("manual", session.metadata.recordingMethod == Metadata.RECORDING_METHOD_MANUAL_ENTRY)
+                        sessionObject.put("stages", stagesArray)
+                        sessionsArray.put(sessionObject)
+                    }
+
+                    val result = JSObject()
+                    result.put("sessions", sessionsArray)
+                    call.resolve(result)
+                } catch (e: Exception) {
+                    call.reject("Error querying sleep: ${e.message}")
+                }
+            }
+        } catch (e: Exception) {
+            call.reject(e.message)
+        }
+    }
+
+    private fun sleepStageName(stage: Int): String {
+        return when (stage) {
+            SleepSessionRecord.STAGE_TYPE_AWAKE, SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED -> "awake"
+            SleepSessionRecord.STAGE_TYPE_SLEEPING -> "asleep"
+            SleepSessionRecord.STAGE_TYPE_LIGHT -> "light"
+            SleepSessionRecord.STAGE_TYPE_DEEP -> "deep"
+            SleepSessionRecord.STAGE_TYPE_REM -> "rem"
+            SleepSessionRecord.STAGE_TYPE_OUT_OF_BED -> "outOfBed"
+            else -> "unknown"
         }
     }
 

--- a/ios/Sources/HealthPluginPlugin/HealthPlugin.swift
+++ b/ios/Sources/HealthPluginPlugin/HealthPlugin.swift
@@ -17,7 +17,8 @@ public class HealthPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "openAppleHealthSettings", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "queryAggregated", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "queryWorkouts", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "queryRecords", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "queryRecords", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "querySleep", returnType: CAPPluginReturnPromise)
     ]
     
     let healthStore = HKHealthStore()
@@ -90,11 +91,13 @@ public class HealthPlugin: CAPPlugin, CAPBridgedPlugin {
             ].compactMap{$0}
         case "READ_MINDFULNESS":
             return [HKObjectType.categoryType(forIdentifier: .mindfulSession)!].compactMap{$0}
+        case "READ_SLEEP":
+            return [HKObjectType.categoryType(forIdentifier: .sleepAnalysis)].compactMap{$0}
         default:
             return []
         }
     }
-    
+
     func aggregateTypeToHKQuantityType(_ dataType: String) -> HKQuantityType? {
         switch dataType {
         case "steps":
@@ -272,6 +275,138 @@ public class HealthPlugin: CAPPlugin, CAPBridgedPlugin {
         // Apple Health de-duplicates data automatically, so per-source record
         // inspection is not needed on iOS.
         call.reject("queryRecords is only available on Android")
+    }
+
+    @objc func querySleep(_ call: CAPPluginCall) {
+        guard let startDateString = call.getString("startDate"),
+              let endDateString = call.getString("endDate"),
+              let startDate = self.isoDateFormatter.date(from: startDateString),
+              let endDate = self.isoDateFormatter.date(from: endDateString) else {
+            call.reject("Invalid parameters")
+            return
+        }
+
+        guard let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis) else {
+            call.reject("Sleep analysis type not available")
+            return
+        }
+
+        // HealthKit has no native session concept, so contiguous samples from the
+        // same source less than this many minutes apart are merged into one session.
+        let gapSeconds = (call.getDouble("sessionGapMinutes") ?? 60.0) * 60.0
+
+        let predicate = HKQuery.predicateForSamples(withStart: startDate, end: endDate, options: .strictStartDate)
+        let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
+
+        let query = HKSampleQuery(sampleType: sleepType, predicate: predicate, limit: HKObjectQueryNoLimit, sortDescriptors: [sortDescriptor]) { _, samples, error in
+            if let error = error {
+                call.reject("Error querying sleep: \(error.localizedDescription)")
+                return
+            }
+
+            guard let categorySamples = samples as? [HKCategorySample] else {
+                call.resolve(["sessions": []])
+                return
+            }
+
+            let sessions = self.groupSleepSamplesIntoSessions(categorySamples, gapSeconds: gapSeconds)
+            call.resolve(["sessions": sessions])
+        }
+
+        healthStore.execute(query)
+    }
+
+    // Cluster samples per source, then split each source's samples into sessions
+    // wherever there is a gap larger than gapSeconds between consecutive samples.
+    private func groupSleepSamplesIntoSessions(_ samples: [HKCategorySample], gapSeconds: TimeInterval) -> [[String: Any]] {
+        var samplesBySource: [String: [HKCategorySample]] = [:]
+        for sample in samples {
+            let bundleId = sample.sourceRevision.source.bundleIdentifier
+            samplesBySource[bundleId, default: []].append(sample)
+        }
+
+        var sessions: [(start: Date, dict: [String: Any])] = []
+
+        for (_, sourceSamples) in samplesBySource {
+            let sorted = sourceSamples.sorted { $0.startDate < $1.startDate }
+            var currentGroup: [HKCategorySample] = []
+            var currentEnd: Date?
+
+            for sample in sorted {
+                if let end = currentEnd, sample.startDate.timeIntervalSince(end) > gapSeconds {
+                    sessions.append((currentGroup.first!.startDate, self.buildSleepSession(from: currentGroup)))
+                    currentGroup = []
+                    currentEnd = nil
+                }
+                currentGroup.append(sample)
+                if currentEnd == nil || sample.endDate > currentEnd! {
+                    currentEnd = sample.endDate
+                }
+            }
+
+            if !currentGroup.isEmpty {
+                sessions.append((currentGroup.first!.startDate, self.buildSleepSession(from: currentGroup)))
+            }
+        }
+
+        return sessions.sorted { $0.start < $1.start }.map { $0.dict }
+    }
+
+    private func buildSleepSession(from samples: [HKCategorySample]) -> [String: Any] {
+        let sorted = samples.sorted { $0.startDate < $1.startDate }
+        let first = sorted.first!
+        let sessionStart = first.startDate
+        let sessionEnd = sorted.map { $0.endDate }.max() ?? sessionStart
+
+        var stages: [[String: Any]] = []
+        var asleepSeconds: TimeInterval = 0
+
+        for sample in sorted {
+            let stageName = self.sleepStageName(forCategoryValue: sample.value)
+            stages.append([
+                "startDate": self.isoDateFormatter.string(from: sample.startDate),
+                "endDate": self.isoDateFormatter.string(from: sample.endDate),
+                "stage": stageName
+            ])
+            if stageName == "asleep" || stageName == "light" || stageName == "deep" || stageName == "rem" {
+                asleepSeconds += sample.endDate.timeIntervalSince(sample.startDate)
+            }
+        }
+
+        return [
+            "id": first.uuid.uuidString,
+            "startDate": self.isoDateFormatter.string(from: sessionStart),
+            "endDate": self.isoDateFormatter.string(from: sessionEnd),
+            "duration": asleepSeconds,
+            "sourceName": first.sourceRevision.source.name,
+            "sourceBundleId": first.sourceRevision.source.bundleIdentifier,
+            "manual": (first.metadata?[HKMetadataKeyWasUserEntered] as? Bool) ?? false,
+            "stages": stages
+        ]
+    }
+
+    private func sleepStageName(forCategoryValue value: Int) -> String {
+        if value == HKCategoryValueSleepAnalysis.inBed.rawValue {
+            return "inBed"
+        }
+        if #available(iOS 16.0, *) {
+            switch value {
+            case HKCategoryValueSleepAnalysis.awake.rawValue:
+                return "awake"
+            case HKCategoryValueSleepAnalysis.asleepUnspecified.rawValue:
+                return "asleep"
+            case HKCategoryValueSleepAnalysis.asleepCore.rawValue:
+                return "light"
+            case HKCategoryValueSleepAnalysis.asleepDeep.rawValue:
+                return "deep"
+            case HKCategoryValueSleepAnalysis.asleepREM.rawValue:
+                return "rem"
+            default:
+                return "unknown"
+            }
+        }
+        // Pre-iOS 16 only exposes inBed (0) and asleep (1).
+        return value == 1 ? "asleep" : "unknown"
     }
 
     func calculateInterval(bucket: String) -> DateComponents? {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -66,6 +66,23 @@ export interface HealthPlugin {
    * @param request
    */
   queryRecords(request: QueryRecordsRequest): Promise<QueryRecordsResponse>;
+
+  /**
+   * Query sleep sessions.
+   *
+   * Android: Reads Health Connect `SleepSessionRecord`s. Each session already
+   * carries its own stages (awake / light / deep / rem / ...).
+   *
+   * iOS: HealthKit has no native sleep-session concept, only individual sleep
+   * analysis category samples. Contiguous samples from the same source are
+   * grouped into a session; samples separated by more than `sessionGapMinutes`
+   * (default 60) start a new session. Each underlying sample becomes a stage.
+   *
+   * Requires the `READ_SLEEP` permission.
+   *
+   * @param request
+   */
+  querySleep(request: QuerySleepRequest): Promise<QuerySleepResponse>;
 }
 
 export declare type HealthPermission =
@@ -76,7 +93,8 @@ export declare type HealthPermission =
   | 'READ_DISTANCE'
   | 'READ_HEART_RATE'
   | 'READ_ROUTE'
-  | 'READ_MINDFULNESS';
+  | 'READ_MINDFULNESS'
+  | 'READ_SLEEP';
 
 export interface PermissionsRequest {
   permissions: HealthPermission[];
@@ -128,7 +146,12 @@ export interface Workout {
 export interface QueryAggregatedRequest {
   startDate: string;
   endDate: string;
-  dataType: 'steps' | 'active-calories' | 'mindfulness';
+  /**
+   * `sleep` returns the total time asleep per bucket (Health Connect's
+   * `SLEEP_DURATION_TOTAL`, in seconds, excluding awake stages). **Android only** —
+   * iOS rejects it; on iOS use `querySleep` and sum the sessions' `duration`.
+   */
+  dataType: 'steps' | 'active-calories' | 'mindfulness' | 'sleep';
   bucket: string;
   /**
    * Optional list of package names (Android) or bundle identifiers (iOS) to
@@ -167,3 +190,48 @@ export interface HealthRecord {
 export interface QueryRecordsResponse {
   records: HealthRecord[];
 }
+
+export interface QuerySleepRequest {
+  startDate: string;
+  endDate: string;
+  /**
+   * iOS only: maximum gap, in minutes, between two consecutive sleep samples
+   * from the same source for them to be treated as part of the same session.
+   * Defaults to 60. Ignored on Android, where Health Connect already groups
+   * samples into sessions.
+   */
+  sessionGapMinutes?: number;
+}
+
+export interface QuerySleepResponse {
+  sessions: SleepSession[];
+}
+
+export interface SleepSession {
+  /** Start of the session (start of the first stage). ISO 8601 string. */
+  startDate: string;
+  /** End of the session (end of the last stage). ISO 8601 string. */
+  endDate: string;
+  /**
+   * Total time asleep in seconds, i.e. the summed duration of the asleep stages
+   * (`light` + `deep` + `rem` + `asleep`). Excludes `awake`, `inBed` and
+   * `outOfBed` stages, so this is typically less than `endDate - startDate`.
+   */
+  duration: number;
+  /** Identifier of the session. On Android this is the record id. */
+  id?: string;
+  sourceName: string;
+  sourceBundleId: string;
+  /** True if the session was entered manually by the user rather than recorded by a device. */
+  manual: boolean;
+  /** Per-stage breakdown of the session, ordered by start time. */
+  stages: SleepStage[];
+}
+
+export interface SleepStage {
+  startDate: string;
+  endDate: string;
+  stage: SleepStageType;
+}
+
+export declare type SleepStageType = 'awake' | 'asleep' | 'light' | 'deep' | 'rem' | 'inBed' | 'outOfBed' | 'unknown';


### PR DESCRIPTION
Addresses #1.

## What

Adds a cross-platform `querySleep()` method (alongside `queryWorkouts` / `queryRecords`) plus a `READ_SLEEP` permission, and extends `queryAggregated()` with an Android-only `'sleep'` dataType — so consumers can read sleep from both Apple Health and Google Health Connect.

## API

```ts
querySleep(request: { startDate: string; endDate: string; sessionGapMinutes?: number })
  => Promise<{ sessions: SleepSession[] }>
```

Each `SleepSession` has `startDate`, `endDate`, `duration` (seconds asleep), `id?`, `sourceName`, `sourceBundleId`, `manual`, and a `stages[]` breakdown (`awake | asleep | light | deep | rem | inBed | outOfBed | unknown`).

`queryAggregated({ dataType: 'sleep', bucket: 'day' })` returns the total time asleep per bucket via Health Connect's `SLEEP_DURATION_TOTAL` (**Android only**; iOS rejects it — on iOS use `querySleep` and sum the sessions' `duration`).

## Platform behavior

- **Android** reads Health Connect `SleepSessionRecord`s directly (sessions are native); each native `STAGE_TYPE_*` maps to a portable stage name.
- **iOS** has no native session concept, so `sleepAnalysis` category samples are grouped **per source** into sessions, splitting whenever consecutive samples are more than `sessionGapMinutes` apart (default 60). Each sample becomes a stage. The iOS-16-only stage values (`awake`, `asleepCore/Deep/REM`) are behind an `if #available(iOS 16.0, *)` guard so the iOS 14 deployment target still builds; pre-16 devices fall back to `inBed`/`asleep`.

`duration` sums only the asleep stages (light + deep + rem + asleep), excluding awake/in-bed time.

## Notes

- New `READ_SLEEP` permission → `android.permission.health.READ_SLEEP` / HealthKit `.sleepAnalysis`.
- README regenerated for the new method/types.
